### PR TITLE
Always add comma between params hash and format key

### DIFF
--- a/lib/rails5/spec_converter/hash_rewriter.rb
+++ b/lib/rails5/spec_converter/hash_rewriter.rb
@@ -32,14 +32,13 @@ class HashRewriter
         joiner: ",\n"
       )
 
-      optional_comma = has_trailing_comma?(hash_node) ? ',' : ''
       new_wrapped_hash_content = wrap_and_indent(
         "{",
         "}",
         [
           wrap_and_indent(
             "params: {",
-            "}#{optional_comma}",
+            "},",
             params_hash,
             @options.indent
           ),

--- a/spec/rails5/text_transformer_spec.rb
+++ b/spec/rails5/text_transformer_spec.rb
@@ -390,6 +390,30 @@ describe Rails5::SpecConverter::TextTransformer do
         end
       RUBY
     end
+
+    it 'adds a comma between the params hash and the format key' do
+      result = transform(<<-RUBY.strip_heredoc)
+        let(:perform_request) do
+          post :show, {
+            branch_name: 'new_design3',
+            ref: 'foo',
+            format: :json
+          }
+        end
+      RUBY
+
+      expect(result).to eq(<<-RUBY.strip_heredoc)
+        let(:perform_request) do
+          post :show, {
+            params: {
+              branch_name: 'new_design3',
+              ref: 'foo'
+            },
+            format: :json
+          }
+        end
+      RUBY
+    end
   end
 
   describe 'things that look like route definitions' do


### PR DESCRIPTION
This comma is not optional; this code path is only taken when there's a format key that needs to be added after the params hash.