### PR TITLE
Fix `$LOAD_PATH` in `exe/rails5-spec-converter`

### DIFF
--- a/exe/rails5-spec-converter
+++ b/exe/rails5-spec-converter
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-$LOAD_PATH.unshift(File.expand_path('../lib', __FILE__))
+$LOAD_PATH.unshift(File.expand_path('../lib', __dir__))
 require 'rails5/spec_converter/cli'
 
 result = Rails5::SpecConverter::CLI.new.run


### PR DESCRIPTION
Fixes:
```
/home/bogdan/.rbenv/versions/2.4.5/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file -- rails5/spec_converter/cli (LoadError)
        from /home/bogdan/.rbenv/versions/2.4.5/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from exe/rails5-spec-converter:4:in `<main>'
```