### PR TITLE
Do not wrap the :headers / :xhr attributes within :params

### DIFF
--- a/lib/rails5/spec_converter/hash_rewriter.rb
+++ b/lib/rails5/spec_converter/hash_rewriter.rb
@@ -1,7 +1,7 @@
 require 'rails5/spec_converter/node_textifier'
 
 class HashRewriter
-  OUTSIDE_PARAMS_KEYS = %i(format)
+  OUTSIDE_PARAMS_KEYS = %i(format headers)
 
   attr_reader :hash_node, :original_indent
 

--- a/lib/rails5/spec_converter/hash_rewriter.rb
+++ b/lib/rails5/spec_converter/hash_rewriter.rb
@@ -1,7 +1,7 @@
 require 'rails5/spec_converter/node_textifier'
 
 class HashRewriter
-  OUTSIDE_PARAMS_KEYS = %i(format headers)
+  OUTSIDE_PARAMS_KEYS = %i(format headers xhr)
 
   attr_reader :hash_node, :original_indent
 

--- a/spec/rails5/text_transformer_spec.rb
+++ b/spec/rails5/text_transformer_spec.rb
@@ -194,6 +194,18 @@ describe Rails5::SpecConverter::TextTransformer do
           get :show, headers: { 'X-BANANA' => 'pancake' }
         RUBY
       end
+
+      describe 'when the :headers key is present' do
+        it 'does not wrap :headers within :params' do
+          result = transform(<<-RUBY.strip_heredoc)
+            get :show, id: 10, headers: { 'X-BANANA' => 'pancake' }
+          RUBY
+
+          expect(result).to eq(<<-RUBY.strip_heredoc)
+            get :show, params: { id: 10 }, headers: { 'X-BANANA' => 'pancake' }
+          RUBY
+        end
+      end
     end
   end
 

--- a/spec/rails5/text_transformer_spec.rb
+++ b/spec/rails5/text_transformer_spec.rb
@@ -196,13 +196,27 @@ describe Rails5::SpecConverter::TextTransformer do
       end
 
       describe 'when the :headers key is present' do
-        it 'does not wrap :headers within :params' do
+        it 'does not wrap it within :params' do
           result = transform(<<-RUBY.strip_heredoc)
             get :show, id: 10, headers: { 'X-BANANA' => 'pancake' }
           RUBY
 
           expect(result).to eq(<<-RUBY.strip_heredoc)
             get :show, params: { id: 10 }, headers: { 'X-BANANA' => 'pancake' }
+          RUBY
+        end
+      end
+    end
+
+    describe 'xhr param' do
+      describe 'when :xhr key is present' do
+        it 'does not wrap it within :params' do
+          result = transform(<<-RUBY.strip_heredoc)
+            get :show, id: 10, xhr: true
+          RUBY
+
+          expect(result).to eq(<<-RUBY.strip_heredoc)
+            get :show, params: { id: 10 }, xhr: true
           RUBY
         end
       end


### PR DESCRIPTION
This PR fixes issue #13: We should wrap the ``:headers`` hash within ``:params`` as ``:headers`` can be used to set HTTP headers when doing HTTP request in rails tests (see [here](https://guides.rubyonrails.org/testing.html#setting-headers-and-cgi-variables)).