### PR TITLE
update: parser deprecations

### DIFF
--- a/lib/rails5/spec_converter/hash_rewriter.rb
+++ b/lib/rails5/spec_converter/hash_rewriter.rb
@@ -1,7 +1,7 @@
 require 'rails5/spec_converter/node_textifier'
 
 class HashRewriter
-  OUTSIDE_PARAMS_KEYS = %i(format)
+  OUTSIDE_PARAMS_KEYS = %i(format xhr headers)
 
   attr_reader :hash_node, :original_indent
 
@@ -21,6 +21,7 @@ class HashRewriter
 
     warn_if_inconsistent_indentation
 
+
     if multiline? && should_wrap_rewritten_hash_in_curly_braces?
       params_hash = restring_hash(
         @pairs_that_belong_in_params,
@@ -32,14 +33,13 @@ class HashRewriter
         joiner: ",\n"
       )
 
-      optional_comma = has_trailing_comma?(hash_node) ? ',' : ''
       new_wrapped_hash_content = wrap_and_indent(
         "{",
         "}",
         [
           wrap_and_indent(
             "params: {",
-            "}#{optional_comma}",
+            "},",
             params_hash,
             @options.indent
           ),
@@ -256,4 +256,9 @@ class HashRewriter
 
     puts str
   end
+
+  def transform_format(params)
+    log params
+  end
+
 end

--- a/lib/rails5/spec_converter/test_type_identifier.rb
+++ b/lib/rails5/spec_converter/test_type_identifier.rb
@@ -21,7 +21,7 @@ module Rails5
         ast_builder = Astrolabe::Builder.new
         @parser = Parser::CurrentRuby.new(ast_builder)
 
-        @source_rewriter = Parser::Source::Rewriter.new(@source_buffer)
+        @source_rewriter = Parser::Source::TreeRewriter.new(@source_buffer)
       end
 
       def test_type

--- a/lib/rails5/spec_converter/text_transformer.rb
+++ b/lib/rails5/spec_converter/text_transformer.rb
@@ -20,7 +20,7 @@ module Rails5
         ast_builder = Astrolabe::Builder.new
         @parser = Parser::CurrentRuby.new(ast_builder)
 
-        @source_rewriter = Parser::Source::Rewriter.new(@source_buffer)
+        @source_rewriter = Parser::Source::TreeRewriter.new(@source_buffer)
       end
 
       def transform

--- a/spec/rails5/text_transformer_spec.rb
+++ b/spec/rails5/text_transformer_spec.rb
@@ -194,6 +194,17 @@ describe Rails5::SpecConverter::TextTransformer do
           get :show, headers: { 'X-BANANA' => 'pancake' }
         RUBY
       end
+      describe 'when the :headers key is present' do
+        it 'does not wrap it within :params' do
+          result = transform(<<-RUBY.strip_heredoc)
+            get :show, id: 10, headers: { 'X-BANANA' => 'pancake' }
+          RUBY
+
+          expect(result).to eq(<<-RUBY.strip_heredoc)
+            get :show, params: { id: 10 }, headers: { 'X-BANANA' => 'pancake' }
+          RUBY
+        end
+      end
     end
   end
 
@@ -386,6 +397,29 @@ describe Rails5::SpecConverter::TextTransformer do
               ref: 'foo',
             },
             format: :json,
+          }
+        end
+      RUBY
+    end
+    it 'adds a comma between the params hash and the format key' do
+      result = transform(<<-RUBY.strip_heredoc)
+        let(:perform_request) do
+          post :show, {
+            branch_name: 'new_design3',
+            ref: 'foo',
+            format: :json
+          }
+        end
+      RUBY
+
+      expect(result).to eq(<<-RUBY.strip_heredoc)
+        let(:perform_request) do
+          post :show, {
+            params: {
+              branch_name: 'new_design3',
+              ref: 'foo'
+            },
+            format: :json
           }
         end
       RUBY


### PR DESCRIPTION
Update the source because `Parser::Source::Rewriter` was deprecated. Instead we need to use `Parser::Source::TreeRewriter` to maintain feature parody. 

@tjgrathwell at-ing because I can't assign, sorry! 🤷‍♂️